### PR TITLE
Add explicit -lc to build-exe arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Because I always wonder these things: the screenshots are in [Kitty terminal](ht
 Requires the Zig programming language to build:
 
 ```
-$ zig build-exe -OReleaseFast prompt.zig
+$ zig build-exe -OReleaseFast -lc prompt.zig
 ```
 
 That creates a binary named `prompt`. I put in `~/bin` so it's in my path.


### PR DESCRIPTION
This is necessary on systems without implicit libc linking to avoid the following error:

```
$ zig build-exe -OReleaseFast prompt.zig
./prompt.zig:119:23: error: C import failed
            const c = @cImport(@cInclude("stdlib.h"));
                      ^
./prompt.zig:119:23: note: libc headers not available; compilation does not link against libc
            const c = @cImport(@cInclude("stdlib.h"));
                      ^
```

(I believe Zig implicitly links libc on MacOS which is why it might not have been necessary for you)